### PR TITLE
Fix Modbus_win.cpp compilation under global WIN32_LEAN_AND_MEAN

### DIFF
--- a/src/win/Modbus_win.cpp
+++ b/src/win/Modbus_win.cpp
@@ -2,10 +2,15 @@
 
 #include <vector>
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <Windows.h>
+#include <timeapi.h>
 #include <initguid.h>
 #include <devguid.h>
 #include <ntddmodm.h>
+#include <ntddser.h>
 #include <setupapi.h>
 
 #define NANOSEC100_IN_MILLISEC      10000


### PR DESCRIPTION
Hi again @serhmarch :)

I want to also surface that when a global `WIN32_LEAN_AND_MEAN` compiler definition is defined in CMake, including the library with `add_subdirectory` in CMake causes a compilation error in `Modbus_win.cpp`.

### Description

When `WIN32_LEAN_AND_MEAN` is defined, some headers normally included with `Windows.h` get discarded. Under this rule, there are two Windows headers missing in `Modbus_win.cpp` which causes the build to fail.

### Solution

In order to be completely agnostic to compiler definitions coming from the outside world, we can define it explicitly and include the missing headers. This ensures that the file will build fine regardless of the initial state.

### Environment

ModbusLib v0.5.0
Windows 11, Visual Studio 2026